### PR TITLE
Use TypeDefinition to wrap mapping of FieldDefinitions

### DIFF
--- a/examples/Ex02_CustomTypeProviders/Ex02_CustomTypeProvidersTest.php
+++ b/examples/Ex02_CustomTypeProviders/Ex02_CustomTypeProvidersTest.php
@@ -12,6 +12,7 @@ namespace PhodamExamples\Ex02_CustomTypeProviders;
 use DateTimeImmutable;
 use Phodam\Analyzer\FieldDefinition;
 use Phodam\Analyzer\TypeAnalysisException;
+use Phodam\Analyzer\TypeDefinition;
 use Phodam\Phodam;
 use Phodam\Provider\ProviderConfig;
 use PHPUnit\Framework\TestCase;
@@ -74,10 +75,11 @@ class Ex02_CustomTypeProvidersTest extends TestCase
 
     public function testTypeDefinitionWithArray(): void
     {
-        $def = [
+        $fields = [
             'students' => (new FieldDefinition(Student::class))
                 ->setArray(true)
         ];
+        $def = new TypeDefinition($fields);
 
         $localPhodam = new Phodam();
         $localPhodam->registerTypeDefinition(Classroom::class, $def);

--- a/src/Phodam/Analyzer/TypeAnalyzer.php
+++ b/src/Phodam/Analyzer/TypeAnalyzer.php
@@ -16,10 +16,10 @@ class TypeAnalyzer
 {
     /**
      * @param string $type
-     * @return array<string, mixed>
+     * @return TypeDefinition
      * @throws ReflectionException|TypeAnalysisException
      */
-    public function analyze(string $type): array
+    public function analyze(string $type): TypeDefinition
     {
         $class = new \ReflectionClass($type);
 
@@ -62,6 +62,7 @@ class TypeAnalyzer
             );
         }
 
-        return $mappedFields;
+        return (new TypeDefinition())
+            ->setFields($mappedFields);
     }
 }

--- a/src/Phodam/Analyzer/TypeDefinition.php
+++ b/src/Phodam/Analyzer/TypeDefinition.php
@@ -1,0 +1,69 @@
+<?php
+
+// This file is part of Phodam
+// Copyright (c) Andrew Vehlies <avehlies@gmail.com>
+// Licensed under the MIT license. See LICENSE file in the project root.
+// SPDX-License-Identifier: MIT
+
+declare(strict_types=1);
+
+namespace Phodam\Analyzer;
+
+class TypeDefinition
+{
+    /** @var array<string, FieldDefinition> */
+    private array $fields;
+
+    /**
+     * @param array<string, FieldDefinition> $fields
+     */
+    public function __construct(array $fields = [])
+    {
+        $this->fields = $fields;
+    }
+
+    /**
+     * @return array<string, FieldDefinition>
+     */
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+
+    /**
+     * @param array<string, FieldDefinition> $fields
+     * @return $this
+     */
+    public function setFields(array $fields): self
+    {
+        $this->fields = $fields;
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     * @param FieldDefinition $definition
+     * @return $this
+     */
+    public function addField(string $name, FieldDefinition $definition): self
+    {
+        $this->fields[$name] = $definition;
+        return $this;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getFieldNames(): array
+    {
+        return array_keys($this->fields);
+    }
+
+    public function getField(string $name): FieldDefinition
+    {
+        if (!array_key_exists($name, $this->fields)) {
+            throw new \Exception('Unable to find field by name: ' . $name);
+        }
+        return $this->fields[$name];
+    }
+}

--- a/src/Phodam/Phodam.php
+++ b/src/Phodam/Phodam.php
@@ -14,6 +14,7 @@ use DateTimeImmutable;
 use InvalidArgumentException;
 use Phodam\Analyzer\FieldDefinition;
 use Phodam\Analyzer\TypeAnalyzer;
+use Phodam\Analyzer\TypeDefinition;
 use Phodam\Provider\Builtin\DefaultDateTimeImmutableTypeProvider;
 use Phodam\Provider\Builtin\DefaultDateTimeTypeProvider;
 use Phodam\Provider\DefinitionBasedTypeProvider;
@@ -89,10 +90,10 @@ class Phodam implements PhodamInterface
 
     /**
      * @param string $type
-     * @param array<string, FieldDefinition> $definition
+     * @param TypeDefinition $definition
      * @return ProviderInterface
      */
-    public function registerTypeDefinition(string $type, array $definition): ProviderInterface
+    public function registerTypeDefinition(string $type, TypeDefinition $definition): ProviderInterface
     {
         $provider = new DefinitionBasedTypeProvider($type, $definition);
         $providerConfig = (new ProviderConfig($provider))

--- a/tests/Phodam/Analyzer/TypeAnalyzerTest.php
+++ b/tests/Phodam/Analyzer/TypeAnalyzerTest.php
@@ -12,6 +12,7 @@ namespace PhodamTests\Phodam\Analyzer;
 use Phodam\Analyzer\FieldDefinition;
 use Phodam\Analyzer\TypeAnalysisException;
 use Phodam\Analyzer\TypeAnalyzer;
+use Phodam\Analyzer\TypeDefinition;
 use PhodamTests\Fixtures\SimpleType;
 use PhodamTests\Fixtures\SimpleTypeMissingSomeFieldTypes;
 use PhodamTests\Fixtures\SimpleTypeWithAnArray;
@@ -45,7 +46,8 @@ class TypeAnalyzerTest extends PhodamBaseTestCase
         ];
 
         $result = $this->analyzer->analyze(SimpleType::class);
-        $this->assertEquals($expected, $result);
+        $this->assertInstanceOf(TypeDefinition::class, $result);
+        $this->assertEquals($expected, $result->getFields());
     }
 
     /**

--- a/tests/Phodam/PhodamTest.php
+++ b/tests/Phodam/PhodamTest.php
@@ -12,6 +12,7 @@ namespace PhodamTests\Phodam;
 use InvalidArgumentException;
 use Phodam\Analyzer\FieldDefinition;
 use Phodam\Analyzer\TypeAnalysisException;
+use Phodam\Analyzer\TypeDefinition;
 use Phodam\Phodam;
 use Phodam\Provider\ProviderConfig;
 use Phodam\Provider\ProviderNotFoundException;
@@ -242,12 +243,13 @@ class PhodamTest extends PhodamBaseTestCase
     public function testRegisterTypeDefinition(): void
     {
         $type = SimpleTypeMissingSomeFieldTypes::class;
-        $definition = [
+        $fields = [
             'myInt' => new FieldDefinition('int'),
             'myFloat' => (new FieldDefinition('float'))->setNullable(true),
             'myString' => new FieldDefinition('string'),
             'myBool' => new FieldDefinition('bool')
         ];
+        $definition = new TypeDefinition($fields);
 
         // try getting a type provider that exists already, it shouldn't, so an exception should be thrown
         try {

--- a/tests/Phodam/Provider/DefinitionBasedTypeProviderTest.php
+++ b/tests/Phodam/Provider/DefinitionBasedTypeProviderTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace PhodamTests\Phodam\Provider;
 
 use Phodam\Analyzer\FieldDefinition;
+use Phodam\Analyzer\TypeDefinition;
 use Phodam\PhodamInterface;
 use Phodam\Provider\DefinitionBasedTypeProvider;
 use Phodam\Provider\UnableToGenerateTypeException;
@@ -54,7 +55,7 @@ class DefinitionBasedTypeProviderTest extends PhodamBaseTestCase
             ]);
 
         $type = SimpleType::class;
-        $definition = [
+        $fields = [
             'myInt' => new FieldDefinition('int'),
             'myFloat' => (new FieldDefinition('float'))
                 ->setNullable(true),
@@ -62,6 +63,7 @@ class DefinitionBasedTypeProviderTest extends PhodamBaseTestCase
                 ->setNullable(true),
             'myBool' => new FieldDefinition('bool')
         ];
+        $definition = new TypeDefinition($fields);
 
         $provider = new DefinitionBasedTypeProvider($type, $definition);
         $provider->setPhodam($this->phodam);
@@ -98,7 +100,7 @@ class DefinitionBasedTypeProviderTest extends PhodamBaseTestCase
             ]);
 
         $type = SimpleType::class;
-        $definition = [
+        $fields = [
             'myInt' => new FieldDefinition('int'),
             'myFloat' => (new FieldDefinition('float'))
                 ->setNullable(true),
@@ -107,6 +109,7 @@ class DefinitionBasedTypeProviderTest extends PhodamBaseTestCase
                 ->setNullable(true),
             'myBool' => new FieldDefinition('bool')
         ];
+        $definition = new TypeDefinition($fields);
 
         $provider = new DefinitionBasedTypeProvider($type, $definition);
         $provider->setPhodam($this->phodam);
@@ -142,7 +145,7 @@ class DefinitionBasedTypeProviderTest extends PhodamBaseTestCase
             ]);
 
         $type = SimpleType::class;
-        $definition = [
+        $fields = [
             'myInt' => new FieldDefinition('int'),
             'myFloat' => (new FieldDefinition('float'))
                 ->setNullable(true),
@@ -150,6 +153,7 @@ class DefinitionBasedTypeProviderTest extends PhodamBaseTestCase
                 ->setNullable(true),
             'myBool' => new FieldDefinition('bool')
         ];
+        $definition = new TypeDefinition($fields);
 
         $provider = new DefinitionBasedTypeProvider($type, $definition);
         $provider->setPhodam($this->phodam);
@@ -185,7 +189,7 @@ class DefinitionBasedTypeProviderTest extends PhodamBaseTestCase
             ]);
 
         $type = SimpleTypeWithoutTypes::class;
-        $definition = [
+        $fields = [
             'myInt' => new FieldDefinition('int'),
             'myFloat' => (new FieldDefinition('float'))
                 ->setNullable(true),
@@ -193,6 +197,7 @@ class DefinitionBasedTypeProviderTest extends PhodamBaseTestCase
                 ->setNullable(true),
             'myBool' => new FieldDefinition('bool')
         ];
+        $definition = new TypeDefinition($fields);
 
         $provider = new DefinitionBasedTypeProvider($type, $definition);
         $provider->setPhodam($this->phodam);
@@ -228,11 +233,12 @@ class DefinitionBasedTypeProviderTest extends PhodamBaseTestCase
             ]);
 
         $type = SimpleTypeMissingSomeFieldTypes::class;
-        $definition = [
+        $fields = [
             'myInt' => new FieldDefinition('int'),
             'myString' => (new FieldDefinition('string'))
                 ->setNullable(true)
         ];
+        $definition = new TypeDefinition($fields);
 
         $provider = new DefinitionBasedTypeProvider($type, $definition);
         $provider->setPhodam($this->phodam);
@@ -257,13 +263,14 @@ class DefinitionBasedTypeProviderTest extends PhodamBaseTestCase
             ->method('create');
 
         $type = SimpleTypeMissingSomeFieldTypes::class;
-        $definition = [
+        $fields = [
             'myInt' => [
                 'type' => 'int',
                 'nullable' => false,
                 'array' => false
             ]
         ];
+        $definition = new TypeDefinition($fields);
 
         $provider = new DefinitionBasedTypeProvider($type, $definition);
         $provider->setPhodam($this->phodam);
@@ -284,11 +291,12 @@ class DefinitionBasedTypeProviderTest extends PhodamBaseTestCase
     public function testCreateSimpleTypeWithAnArray()
     {
         $type = SimpleTypeWithAnArray::class;
-        $definition = [
+        $fields = [
             'myInt' => new FieldDefinition('int'),
             'myArray' => (new FieldDefinition(SimpleType::class))
                 ->setArray(true)
         ];
+        $definition = new TypeDefinition($fields);
 
         $this->phodam
             ->method('create')


### PR DESCRIPTION
In #13, I added a new class `FieldDefinition` and started treating type definitions as `array<string, FieldDefinition>`, but now I've introduced `TypeDefinition` which wraps around that array.

Doing
```php
$fields = [
    'myInt' => new FieldDefinition('int'),
    'myArrayOfStrings' => (new FieldDefinition('string'))->setArray(true)
];
$definition = new TypeDefinition($fields);
```
is also kinda ugly.

Maybe it's prettier to just do:
```php
$definition = (new TypeDefinition())
    ->addField('myInt', new FieldDefinition('int'))
    ->addField('myArrayOfStrings' => (new FieldDefinition('string'))->setArray(true));
```

I do like the idea of the fluent builders like:
```php
$definition = TypeDefinition::builder()
    ->newField('myInt')
    ->setType('int')
    ->add()
    ->newField('myArrayOfStrings')
    ->setType('string')
    ->setArray(true)
    ->add();
```
which I think is what you were doing with Provider config? Or something like that in your other merge requests.

I'd like to revisit `TypeDefinition` and `FieldDefinition` to be "prettier" but I'm not sure I want to yet because I want all of the things that need to be built to be done _consistently_ with each other, and it seems like I'm not set on how I really want that to be done.

It would probably be worth a discussion after the api-tweaks of how to consistently implement all of these building/registering patterns. That being said, I'm fine *NOT* merging this until we have that discussion.